### PR TITLE
修复两个bug

### DIFF
--- a/dataSource/sourceBank.py
+++ b/dataSource/sourceBank.py
@@ -62,8 +62,9 @@ class SourceBank(DownloadTools):
     def get_pic(self, name, _type, _source='gitee', _save_ignore=True):
 
         ignore = self.get_ignore()
-
-        url = f'{self.pics_source[_source]}/{name}.png'
+        
+        escape_name = name.repalce("#", "%23")
+        url = f'{self.pics_source[_source]}/{escape_name}.png'
         save_path = f'{self.pics_path}/{_type}'
         image_path = f'{save_path}/{name.split("/")[-1]}.png'
 

--- a/handlers/functions/arknights/recruit/__init__.py
+++ b/handlers/functions/arknights/recruit/__init__.py
@@ -136,7 +136,7 @@ class Recruit(FuncInterface):
                 else:
                     text = '博士，没有找到可以锁定稀有干员的组合'
 
-                return Chain(data).text(text)
+                return Chain(data).text_image(text)
             else:
                 return Chain(data).text('博士，无法查询到标签所拥有的稀有干员')
         else:


### PR DESCRIPTION
当公招分析结果长度过短时，不会转换为图片(偶发)
当url含有字符#时，下载图片会下载失败