### PR TITLE
修复 sourceBank.py 中字符串替换方法单词拼写错误

### DIFF
--- a/dataSource/sourceBank.py
+++ b/dataSource/sourceBank.py
@@ -63,7 +63,7 @@ class SourceBank(DownloadTools):
 
         ignore = self.get_ignore()
         
-        escape_name = name.repalce("#", "%23")
+        escape_name = name.replace("#", "%23")
         url = f'{self.pics_source[_source]}/{escape_name}.png'
         save_path = f'{self.pics_path}/{_type}'
         image_path = f'{save_path}/{name.split("/")[-1]}.png'


### PR DESCRIPTION
修复在上个合并更改中 `sourceBank.py` 第 66 行 `name.repalce(...)` 方法名拼写错误导致启动报错:
* AttributeError: 'str' object has no attribute 'repalce'

修复为正确拼写 `replace`