### PR TITLE
fix 修复 gamedata 资源压缩包解压失败bug

### DIFF
--- a/core/resource/arknightsGameData/__init__.py
+++ b/core/resource/arknightsGameData/__init__.py
@@ -1,12 +1,11 @@
 import os
 import re
-import shutil
 import zipfile
 
 from typing import List, Dict, Tuple
 from core.network.download import download_sync, download_async
 from core.resource import resource_config
-from core.util import Singleton, remove_xml_tag, remove_punctuation, create_dir, sorted_dict
+from core.util import Singleton, remove_xml_tag, remove_punctuation, create_dir, sorted_dict, remove_dir
 from core import log
 
 from .common import ArknightsConfig, JsonData
@@ -261,7 +260,7 @@ class ArknightsGameDataResource:
     def unpack_gamedata_files(cls, path):
         log.info(f'unpacking {path}...')
 
-        shutil.rmtree(gamedata_path)
+        remove_dir(gamedata_path)
         create_dir(gamedata_path)
 
         pack = zipfile.ZipFile(path)

--- a/core/util.py
+++ b/core/util.py
@@ -4,6 +4,7 @@ import time
 import yaml
 import jieba
 import jionlp
+import shutil
 import string
 import random
 import difflib
@@ -217,6 +218,12 @@ def char_seat(char):
 
 def text_to_pinyin(text: str):
     return ''.join([item[0] for item in pypinyin.pinyin(text, style=pypinyin.NORMAL)]).lower()
+
+
+def remove_dir(path: str):
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    return path
 
 
 def remove_punctuation(text: str):


### PR DESCRIPTION
修复类方法 `unpack_gamedata_files` 中：
* `shutil.rmtree` 方法在资源目录 `resource/gamedata` 不存在时抛出异常，跳过后续的解压操作

此问题会导致读取和更新资源失败