### PR TITLE
fix 避免同步卡池命令等待回复超时报错

### DIFF
--- a/functions/admin.py
+++ b/functions/admin.py
@@ -136,7 +136,7 @@ async def _(data: Message):
 async def _(data: Message):
     if data.is_admin:
         confirm = await data.waiting(Chain(data).text('同步将使用官方DEMO的卡池数据覆盖现有设置，回复"确认"开始同步。'))
-        if confirm.text == '确认':
+        if confirm.text == '确认' and not confirm is None:
             await data.send(Chain(data).text(f'开始同步'))
 
             res = await download_async(official_console + '/pool/getGachaPool', stringify=True)


### PR DESCRIPTION
在使用同步卡池命令等待回复期间，等待十多秒后超时并抛出 `confirm` 对象为空类型错误，此合并将避免这个报错：

* line 139      'NoneType' object has no attribute 'text'