### PR TITLE
为公招功能实现了基于飞桨的本地OCR并为core/util.py添加部分注释

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Amiya-Bot 的所有说明均可查阅本项目的官方网站 [https://www.amiya
     - [微博移动版](https://m.weibo.cn)
 - 抽卡图片合成逻辑参考
     - [刀客塔的办公室](https://github.com/Rominwolf/doctors_office)
+- 文字识别
+    - [飞桨OCR](https://github.com/PaddlePaddle/PaddleOCR)
 
 ## 共生项目
 

--- a/config/private/recruit.yaml
+++ b/config/private/recruit.yaml
@@ -1,3 +1,9 @@
 autoDiscern:
     templateHash: 298539435919003337906396405361402448896
     maxDifferent: 25
+
+replace:
+    - key: "千员"
+      val: "干员"
+    - key: ".击干员"
+      val: "狙击干员"

--- a/core/builtin/localOcr.py
+++ b/core/builtin/localOcr.py
@@ -1,0 +1,29 @@
+"""
+    Copyright 2022 AmiyaBot
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+import aiofiles.os
+from paddleocr import PaddleOCR
+
+from core.util import Singleton
+
+
+class LocalOCR(metaclass=Singleton):
+    def __init__(self):
+        self.__ocr = PaddleOCR(lang="ch")
+
+    async def ocr(self, path: str):
+        result = [text[1][0] for text in self.__ocr.ocr(path)]
+        await aiofiles.os.remove(path)
+        return result

--- a/core/builtin/localOcr.py
+++ b/core/builtin/localOcr.py
@@ -14,14 +14,14 @@
    limitations under the License.
 """
 import aiofiles.os
-from paddleocr import PaddleOCR
 
+from paddleocr import PaddleOCR
 from core.util import Singleton
 
 
 class LocalOCR(metaclass=Singleton):
     def __init__(self):
-        self.__ocr = PaddleOCR(lang="ch")
+        self.__ocr = PaddleOCR(lang='ch')
 
     async def ocr(self, path: str):
         result = [text[1][0] for text in self.__ocr.ocr(path)]

--- a/core/util.py
+++ b/core/util.py
@@ -1,8 +1,6 @@
 import re
 import os
 import time
-from typing import List
-
 import yaml
 import jieba
 import jionlp
@@ -13,11 +11,12 @@ import difflib
 import asyncio
 import datetime
 import pypinyin
-from paddleocr import paddleocr
 
 from yaml import SafeDumper
+from typing import List
 from string import punctuation
 from attrdict import AttrDict
+from paddleocr import paddleocr
 from functools import partial
 from zhon.hanzi import punctuation as punctuation_cn
 from concurrent.futures import ThreadPoolExecutor

--- a/core/util.py
+++ b/core/util.py
@@ -13,6 +13,7 @@ import difflib
 import asyncio
 import datetime
 import pypinyin
+from paddleocr import paddleocr
 
 from yaml import SafeDumper
 from string import punctuation
@@ -22,6 +23,7 @@ from zhon.hanzi import punctuation as punctuation_cn
 from concurrent.futures import ThreadPoolExecutor
 
 jieba.setLogLevel(jieba.logging.INFO)
+paddleocr.logging.disable()
 
 yaml_cache = {
     'attr': {},
@@ -42,7 +44,7 @@ async def run_in_thread_pool(block_func, *args, **kwargs):
         res = await run_in_thread_pool(func, index)
 
     :param block_func: IO阻塞型函数
-    :param args:       元祖参数
+    :param args:       元组参数
     :param kwargs:     字典参数
     :return:
     """
@@ -55,6 +57,11 @@ class TimeRecorder:
         self.time = time.time()
 
     def rec(self, millisecond=False):
+        """
+        获取从开始计时到调用时经过了多少秒/毫秒
+        :param millisecond: 是否适用毫秒计时
+        :return: 单位为秒/毫秒的时间
+        """
         mil = 1000 if millisecond else 1
         return int(time.time() * mil - self.time * mil)
 
@@ -63,11 +70,20 @@ class TimeRecorder:
 
     @staticmethod
     def calc_time_total(seconds):
+        """
+        将秒数转化为日常计时
+        :param seconds: 秒数
+        :return: 日常计时
+        """
+        # 将秒数转化为日常计时中 天数+小时+分钟+秒 的形式
         timedelta = datetime.timedelta(seconds=seconds)
+        # 获取天数
         day = timedelta.days
+        # 获取 时、分、秒
         hour, mint, sec = tuple([
             int(n) for n in str(timedelta).split(',')[-1].split(':')
         ])
+        # 转化成汉语字符串
         total = ''
         if day:
             total += '%d天' % day
@@ -75,12 +91,14 @@ class TimeRecorder:
             total += '%d小时' % hour
         if mint:
             total += '%d分钟' % mint
+        # 如果时间超过一分钟，则不显示秒数
         if sec and not (day or hour or mint):
             total += '%d秒' % sec
 
         return total
 
 
+# 使用metaclass实现单例类
 class Singleton(type):
     instances = {}
 
@@ -90,11 +108,18 @@ class Singleton(type):
         return cls.instances[cls]
 
 
+# 变成按照一定规则将data的key值排序后的有序字典
 def sorted_dict(data: dict, *args, **kwargs):
     return {n: data[n] for n in sorted(data, *args, **kwargs)}
 
 
 def all_match(text: str, items: list):
+    """
+    判断text中是否包含items中的所有元素
+    :param text: 源文本
+    :param items: 待匹配元素列表
+    :return: 是否匹配
+    """
     for item in items:
         if item not in text:
             return False
@@ -102,17 +127,31 @@ def all_match(text: str, items: list):
 
 
 def any_match(text: str, items: list):
+    """
+    判断text中是否包含items中的任一元素
+    :param text: 源文本
+    :param items: 待匹配元素列表
+    :return: 是否匹配
+    """
     for item in items:
         if item in text:
             return True
     return False
 
 
+# 在元素列表中随机选出其中一个
 def random_pop(items: list):
     return items.pop(random.randrange(0, len(items)))
 
 
 def check_sentence_by_re(sentence: str, words: list, names: list):
+    """
+    按照words的正则表达式在sentence中匹配names中的任一元素
+    :param sentence: 待匹配文本
+    :param words: 正则列表
+    :param names: 填充列表
+    :return: 是否匹配
+    """
     for item in words:
         for n in names:
             if re.search(re.compile(item % n if '%s' in item else item), sentence):
@@ -121,6 +160,13 @@ def check_sentence_by_re(sentence: str, words: list, names: list):
 
 
 def find_similar_list(text: str, text_list: list, _random: bool = False):
+    """
+    在text_list中找到和text最接近的字符串
+    :param text: 参考字符串
+    :param text_list: 待选字符串列表
+    :param _random: 若为True，如果有多个字符串与text的相似程度相同，则返回其中任意一个，若为False，则返回所有最接近的字符串
+    :return: 最接近的字符串/字符串列表
+    """
     result = {}
     for item in text_list:
         rate = float(
@@ -144,6 +190,13 @@ def find_similar_list(text: str, text_list: list, _random: bool = False):
 
 
 def read_yaml(path: str, _dict: bool = False, _refresh=True):
+    """
+    读取yaml配置文件
+    :param path: 文件路径
+    :param _dict: 若为True，返回一个dict，否则返回AttrDict
+    :param _refresh: 若为True或该文件没有被缓存，则从文件中读取，否则从缓存中读取
+    :return: dict/AttrDict形式的配置
+    """
     t = 'dict' if _dict else 'attr'
 
     if path in yaml_cache[t] and not _refresh:
@@ -160,6 +213,13 @@ def read_yaml(path: str, _dict: bool = False, _refresh=True):
 
 
 def create_yaml(path: str, data: dict, overwrite: bool = False):
+    """
+    根据data创建yaml配置文件
+    :param path: 文件路径
+    :param data: 配置数据
+    :param overwrite: 是否在该path所指向的文件存在时重写yaml
+    :return: 是否成功创建
+    """
     SafeDumper.add_representer(
         type(None),
         lambda dumper, value: dumper.represent_scalar(u'tag:yaml.org,2002:null', '')
@@ -176,6 +236,12 @@ def create_yaml(path: str, data: dict, overwrite: bool = False):
 
 
 def create_dir(path: str, is_file: bool = False):
+    """
+    创建文件/目录
+    :param path: 文件/目录路径
+    :param is_file: 该path是否为文件
+    :return: 标准的文件/目录路径
+    """
     if is_file:
         path = '/'.join(path.replace('\\', '/').split('/')[:-1])
 
@@ -366,6 +432,11 @@ def chinese_to_digits(text: str):
 
 
 def is_all_chinese(text: List[str]):
+    """
+    判断列表中所有的字符串是否全部为汉字
+    :param text: 字符串列表
+    :return: 是否全为汉字
+    """
     for word in text:
         for char in word:
             if not '\u4e00' <= char <= '\u9fff':

--- a/functions/arknights/recruit.py
+++ b/functions/arknights/recruit.py
@@ -1,3 +1,9 @@
+import os
+import re
+import time
+
+import aiofiles
+import aiofiles.os
 import dhash
 import jieba
 
@@ -7,13 +13,18 @@ from jieba import posseg
 from typing import List
 from itertools import combinations
 from core import exec_before_init, log, bot, Message, Chain
+from core.builtin.localOcr import LocalOCR
+from core.config import config
 from core.util import insert_empty, all_match, read_yaml
 from core.builtin.baiduCloud import BaiduCloud
 from core.network.download import download_async
 from core.resource.arknightsGameData import ArknightsGameData
 
 baidu = BaiduCloud()
-discern = read_yaml('config/private/recruit.yaml').autoDiscern
+local_ocr = LocalOCR()
+recruit_config = read_yaml('config/private/recruit.yaml')
+discern = recruit_config.autoDiscern
+replace = recruit_config.replace
 
 
 def find_operator_tags_by_tags(tags, max_rarity):
@@ -62,12 +73,23 @@ async def auto_discern(data: Message):
 
 
 async def get_ocr_result(image):
-    res = await baidu.basic_accurate(image)
-    if not res:
-        res = await baidu.basic_general(image)
+    if config.baiduCloud.enable:
+        res = await baidu.basic_accurate(image)
+        if not res:
+            res = await baidu.basic_general(image)
 
-    if res and 'words_result' in res:
-        return ''.join([item['words'] for item in res['words_result']])
+        if res and 'words_result' in res:
+            return ''.join([item['words'] for item in res['words_result']])
+
+    if not os.path.exists('fileStorage/recruit/'):
+        await aiofiles.os.mkdir('fileStorage/recruit/')
+    path = 'fileStorage/recruit/' + str(time.time()) + '.jpg'
+    async with aiofiles.open(path, mode='wb+') as f:
+        await f.write(image)
+    res = ''.join(await local_ocr.ocr(path))
+    for regex in replace:
+        res = re.sub(regex.key, regex.val, res)
+    return res
 
 
 class Recruit:

--- a/functions/arknights/recruit.py
+++ b/functions/arknights/recruit.py
@@ -1,11 +1,10 @@
 import os
 import re
 import time
-
-import aiofiles
-import aiofiles.os
 import dhash
 import jieba
+import aiofiles
+import aiofiles.os
 
 from io import BytesIO
 from PIL import Image
@@ -83,9 +82,12 @@ async def get_ocr_result(image):
 
     if not os.path.exists('fileStorage/recruit/'):
         await aiofiles.os.mkdir('fileStorage/recruit/')
+
     path = 'fileStorage/recruit/' + str(time.time()) + '.jpg'
+
     async with aiofiles.open(path, mode='wb+') as f:
         await f.write(image)
+
     res = ''.join(await local_ocr.ocr(path))
     for regex in replace:
         res = re.sub(regex.key, regex.val, res)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp~=3.8.1
+aiofiles~=0.8.0
 attrdict~=2.0.1
 baidu-aip~=2.2.18.0
 dhash~=1.3
@@ -8,6 +9,7 @@ graiax-silkcoder~=0.0.16
 jieba~=0.42.1
 jinja2~=3.0.3
 jionlp~=1.3.47
+paddleocr~=2.4.0
 passlib~=1.7.4
 peewee~=3.14.8
 pillow~=9.0.0


### PR DESCRIPTION
实现了基于飞桨的本地OCR，在用户未启用百度云服务或出于种种原因调用百度云OCR服务失败（诸如OCR服务调用次数超限、apiKey值配置出错）时调用基于飞桨的本地OCR。
根据飞桨OCR所使用的 Apache License 2.0 要求，已在相关文件的文件头添加说明。
为了便于实现，添加了aiofiles与paddleocr的依赖，已补充至requirements.txt中。
修改了config/private/recruit.yaml文件，添加了配置项replace，该配置项是一个数组，目的在于提高飞桨OCR的准确率，替换掉常见错误。数组中的每一项均为包含key、val两项的配置项，在对公招的文字进行OCR后，当文字中的某一段可以被key匹配时，将之替换为val，其中key项支持正则字符串，val项为字符串。replace配置项受限于个人兔兔用户有限，目前暂不全面，需要在使用中不断添加、调整，因而有待改进。
同时修改了README.md，添加了对飞桨OCR的鸣谢。

另外为core/util.py添加了部分注释，增加了可读性，受限于个人能力，无法保证完全正确地理解每一行代码的用途，可能会有部分注释不正确、不完善、不规范。

Allow edits by maintainers