### PR TITLE
fix 无模组干员查询模组异常

### DIFF
--- a/functions/arknights/operator/__init__.py
+++ b/functions/arknights/operator/__init__.py
@@ -162,7 +162,10 @@ async def _(data: Message):
 
     if info.name not in ArknightsGameData().operators:
         return Chain(data).text(f'博士，没有找到干员"{info.name}"')
-
+    
+    if OperatorData.find_operator_module(info, False) == []:
+        return Chain(data).text(f'博士，干员"{info.name}"还没有模组')
+    
     if '故事' in data.text:
         result = OperatorData.find_operator_module(info, True)
         return Chain(data).text_image(result)


### PR DESCRIPTION
无模组干员在查询模组时会返回黑色的背景图
在应答前简单做了个判断
没深入阅读源代码 不确定有没有例外情况