### PR TITLE
pip install/懒加载/用户Meta

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -62,14 +62,14 @@ async def load_plugins():
     create_dir('plugins')
     count = 0
     for root, dirs, files in os.walk('plugins'):
-        for dir_name in dirs:
-            req_file = os.path.join(root, f'{dir_name}/requirements.txt')
-            if os.path.exists(req_file):
-                log.info(f'installing requirements {req_file}')
-                try:
-                    subprocess.run([sys.executable, "-m", "pip", "install", "-r", req_file, "-i","https://pypi.tuna.tsinghua.edu.cn/simple"])
-                except Exception as e:
-                    log.error(f'install requirements error:{e}')
+#         for dir_name in dirs:
+#             req_file = os.path.join(root, f'{dir_name}/requirements.txt')
+#             if os.path.exists(req_file):
+#                 log.info(f'installing requirements {req_file}')
+#                 try:
+#                     subprocess.run([sys.executable, "-m", "pip", "install", "-r", req_file, "-i","https://pypi.tuna.tsinghua.edu.cn/simple"])
+#                 except Exception as e:
+#                     log.error(f'install requirements error:{e}')
 
         for file in files:
             if file.endswith('.zip'):

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -42,6 +42,10 @@ async def load_plugins():
     create_dir('plugins')
     count = 0
     for root, dirs, files in os.walk('plugins'):
+        for dir_name in dirs:
+            req_file = os.path.join(root, f'{dir_name}/requirements.txt')
+            if os.path.exists(req_file):
+                subprocess.call([sys.executable, "-m", "pip", "install", "-r", req_file, "-i","https://pypi.tuna.tsinghua.edu.cn/simple"])
         for file in files:
             if file.endswith('.zip'):
                 res = bot.install_plugin(os.path.join(root, file), extract_plugin=True)

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,9 +2,11 @@ import os
 import copy
 import time
 import traceback
+import subprocess
+import sys
 
 from typing import List
-from amiyabot import MultipleAccounts, HttpServer, Message, Chain, ChainBuilder, Equal, log
+from amiyabot import MultipleAccounts, HttpServer, Message, Chain, ChainBuilder, Equal, log, PluginInstance
 from amiyabot.adapters import BotAdapterProtocol
 from amiyabot.adapters.tencent import TencentBotInstance
 from amiyabot.network.httpRequests import http_requests
@@ -30,6 +32,24 @@ tasks_control = TasksControl()
 
 message_record = []
 
+class LazyLoadPluginInstance(PluginInstance):
+    def __init__(self,
+                 name: str,
+                 version: str,
+                 plugin_id: str,
+                 plugin_type: str = None,
+                 description: str = None,
+                 document: str = None):
+        super().__init__(
+            name,
+            version,
+            plugin_id,
+            plugin_type,
+            description,
+            document
+        )
+    
+    def load(self): ...
 
 def load_resource():
     gamedata_repo.update()
@@ -45,12 +65,29 @@ async def load_plugins():
         for dir_name in dirs:
             req_file = os.path.join(root, f'{dir_name}/requirements.txt')
             if os.path.exists(req_file):
-                subprocess.call([sys.executable, "-m", "pip", "install", "-r", req_file, "-i","https://pypi.tuna.tsinghua.edu.cn/simple"])
+                log.info(f'installing requirements {req_file}')
+                try:
+                    subprocess.run([sys.executable, "-m", "pip", "install", "-r", req_file, "-i","https://pypi.tuna.tsinghua.edu.cn/simple"])
+                except Exception as e:
+                    log.error(f'install requirements error:{e}')
+
         for file in files:
             if file.endswith('.zip'):
-                res = bot.install_plugin(os.path.join(root, file), extract_plugin=True)
-                if res:
-                    count += 1
+                log.info(f'installing plugins {file}')
+                try:
+                    res = bot.install_plugin(os.path.join(root, file), extract_plugin=True)
+                    if res:
+                        count += 1
+                except Exception as e:
+                    log.error(f'install plugins error:{e}')
+
+    # 然后对所有插件执行懒加载（如果有的话）
+    
+    for plugin_id, item in bot.plugins.items():
+        # log.info(f'lazy load plugins {plugin_id},{type(item)}')
+        if isinstance(item, LazyLoadPluginInstance):
+            log.info(f'lazy load plugins {plugin_id}')
+            item.load()
 
     if count:
         log.info(f'successfully loaded {count} plugin(s).')


### PR DESCRIPTION
这个PR里有三个改动：
1、加入对插件路径执行 pip install -r requirements.txt 的操作
在加载所有插件前，他会遍历每个文件夹寻找requirements.txt，如果有，就会调用pip进行安装

2、加入一个LazyLoadPluginInstance，为插件提供对抗依赖的手段
未来，如果插件之间互相产生依赖，为了防止A插件加载时，他依赖的B插件还没加载，加入一个load虚函数，涉及到插件依赖的代码可以移动到虚函数load中，当load被调用时，bot承诺所有插件的install都已经执行。

3、增加一个新的用户字段meta_json
除了新字段，还增加了两个新函数用于get meta和set meta，这样插件可以通过这个，在用户级别上，保存持久化数据。
但是因为python没有private能力，其他插件可以轻易毁掉另一个插件辛苦积累的数据，不过这是py，没办法