### PR TITLE
动态提供Schema的能力

### DIFF
--- a/core/customPluginInstance/amiyaBotPluginInstance.py
+++ b/core/customPluginInstance/amiyaBotPluginInstance.py
@@ -4,7 +4,7 @@ import copy
 import jsonschema
 
 from peewee import *
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Callable
 from core.database.plugin import PluginConfiguration, PluginConfigurationAudit
 from core.util import read_yaml
 from datetime import datetime, timedelta
@@ -14,6 +14,7 @@ from .lazyLoadPluginInstance import LazyLoadPluginInstance
 
 JSON_VALUE_TYPE = Optional[Union[bool, str, int, float, dict, list]]
 CONFIG_TYPE = Optional[Union[str, dict]]
+DYNAMIC_CONFIG_TYPE = Optional[Union[str, dict, Callable[[], Union[dict, list]]]]
 
 global_config_channel_key = ''
 
@@ -30,18 +31,24 @@ class AmiyaBotPluginInstance(LazyLoadPluginInstance):
         priority: int = 1,
         instruction: str = None,
         channel_config_default: CONFIG_TYPE = None,
-        channel_config_schema: CONFIG_TYPE = None,
+        channel_config_schema: DYNAMIC_CONFIG_TYPE  = None,
         global_config_default: CONFIG_TYPE = None,
-        global_config_schema: CONFIG_TYPE = None,
+        global_config_schema: DYNAMIC_CONFIG_TYPE  = None,
         deprecated_config_delete_days: int = 7,
     ):
         super().__init__(name, version, plugin_id, plugin_type, description, document, priority)
 
         self.instruction = instruction
         self.__channel_config_default = self.__parse_to_json(channel_config_default)
-        self.__channel_config_schema = self.__parse_to_json(channel_config_schema)
         self.__global_config_default = self.__parse_to_json(global_config_default)
-        self.__global_config_schema = self.__parse_to_json(global_config_schema)
+
+        self.__channel_config_schema = channel_config_schema
+        self.__global_config_schema = global_config_schema
+
+        # 原地获取一次,目的是校验
+        _ = self.__get_dynamic_channel_config_schema()
+        _ = self.__get_dynamic_global_config_schema()
+
         self.__deprecated_config_delete_days = deprecated_config_delete_days
 
         self.validate_schema()
@@ -113,7 +120,7 @@ class AmiyaBotPluginInstance(LazyLoadPluginInstance):
         except Exception as e:
             log.error(e, f"Error")
 
-    # 如果距离插件更新已经过去天，移除既不存在于default，也不存在于Schema的配置项。
+    # 如果距离插件更新已经过去X天，移除既不存在于default，也不存在于Schema的配置项。
     # 然后写入Audit信息。
     def deprecated_config_delete(self):
         if self.__deprecated_config_delete_days is None or self.__deprecated_config_delete_days < 0:
@@ -170,7 +177,7 @@ class AmiyaBotPluginInstance(LazyLoadPluginInstance):
                     # 全局配置
                     cfg = self.__get_global_config()
                     if cfg is not None:
-                        remove_uncommon_elements(cfg, self.__global_config_default, self.__global_config_schema)
+                        remove_uncommon_elements(cfg, self.__global_config_default, self.__get_dynamic_global_config_schema())
                         self.__set_global_config(cfg)
                         PluginConfigurationAudit.create(
                             plugin_id=self.plugin_id,
@@ -183,7 +190,7 @@ class AmiyaBotPluginInstance(LazyLoadPluginInstance):
                     log.info(f'频道{channel_id}配置的配置项需要检查并剔除老旧配置项。')
                     cfg = self.__get_channel_config(channel_id)
                     if cfg is not None:
-                        remove_uncommon_elements(cfg, self.__channel_config_default, self.__channel_config_schema)
+                        remove_uncommon_elements(cfg, self.__channel_config_default, self.__get_dynamic_channel_config_schema())
                         self.__set_channel_config(channel_id, cfg)
                         PluginConfigurationAudit.create(
                             plugin_id=self.plugin_id,
@@ -195,8 +202,8 @@ class AmiyaBotPluginInstance(LazyLoadPluginInstance):
 
     def validate_schema(self):
         for default, schema in (
-            (self.__channel_config_default, self.__channel_config_schema),
-            (self.__global_config_default, self.__global_config_schema),
+            (self.__channel_config_default, self.__get_dynamic_channel_config_schema()),
+            (self.__global_config_default, self.__get_dynamic_global_config_schema()),
         ):
             # 提供 Template 则立即执行校验
             if schema is not None:
@@ -209,16 +216,25 @@ class AmiyaBotPluginInstance(LazyLoadPluginInstance):
                 except jsonschema.ValidationError as e:
                     raise ValueError('Your json default does not fit your schema.') from e
 
+    def __get_dynamic_channel_config_schema(self):
+        return self.__parse_to_json(self.__channel_config_schema)
+
+    def __get_dynamic_global_config_schema(self):
+        return self.__parse_to_json(self.__global_config_schema) 
+
     def get_config_defaults(self):
         return {
             'channel_config_default': json.dumps(self.__channel_config_default),
-            'channel_config_schema': json.dumps(self.__channel_config_schema),
+            'channel_config_schema': json.dumps(self.__get_dynamic_channel_config_schema()),
             'global_config_default': json.dumps(self.__global_config_default),
-            'global_config_schema': json.dumps(self.__global_config_schema),
+            'global_config_schema': json.dumps(self.__get_dynamic_global_config_schema()),
         }
 
     @staticmethod
-    def __parse_to_json(value: CONFIG_TYPE) -> CONFIG_TYPE:
+    def __parse_to_json(value: DYNAMIC_CONFIG_TYPE) -> CONFIG_TYPE:
+        if callable(value):
+            value = value()
+            
         if not value:
             return None
 


### PR DESCRIPTION
我修改了PluginInstace让他的Schema支持动态获取。
具体来说，就是让Schema支持传入一个函数（很好这很Python）
每次读取Schema时，都会现场执行这个函数，要他提供一个字符串/路径/Dict。

这个功能的目的是实现下面这个效果。
![image](https://github.com/AmiyaBot/Amiya-Bot/assets/5977110/442ef67e-0de8-40f3-b82c-d97d06527082)
这个下拉框是根据WebApi的查询结果动态构建的。每次用户刷新Console，获取到的列表会不一样，取决于当前Api的返回值缓存。

需要在文档里提醒用户，这个函数需要快速返回，否则会导致Console卡死或超时，建议像我一样，用另一个线程获取数据并缓存，Schema函数仅展示缓存数据。

