### PR TITLE
feat: 动态Scheme的能力+将插件加载提前

### DIFF
--- a/amiya.py
+++ b/amiya.py
@@ -25,4 +25,5 @@ def run_amiya(*tasks: Coroutine):
 
 if __name__ == '__main__':
     loader = PluginsLoader(bot)
-    run_amiya(bot.start(launch_browser=True), app.serve(), loader.load_local_plugins())
+    asyncio.run(loader.load_local_plugins())
+    run_amiya(bot.start(launch_browser=True), app.serve())

--- a/core/plugins/customPluginInstance/amiyaBotPluginInstance.py
+++ b/core/plugins/customPluginInstance/amiyaBotPluginInstance.py
@@ -33,9 +33,9 @@ class AmiyaBotPluginInstance(PluginInstance):
         instruction: str = None,
         requirements: Optional[List[Requirement]] = None,
         channel_config_default: CONFIG_TYPE = None,
-        channel_config_schema: CONFIG_TYPE = None,
+        channel_config_schema: DYNAMIC_CONFIG_TYPE = None,
         global_config_default: CONFIG_TYPE = None,
-        global_config_schema: CONFIG_TYPE = None,
+        global_config_schema: DYNAMIC_CONFIG_TYPE = None,
         deprecated_config_delete_days: int = 7,
     ):
         super().__init__(name, version, plugin_id, plugin_type, description, document, priority)


### PR DESCRIPTION
两个改动，第一个是动态Scheme能力，这个我在下个comment把上一个PR的comment拷过来。

第二个改动，我把插件加载提前了，让他在bot启动前单独跑，跑完了才可以跑bot启动和app serve，目的是解决其他插件借用fastapi的app对象，会因为延迟加载而无效的问题。