### PR TITLE
No module named 'qcloud_cos' Fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,8 @@ peewee~=3.14.10
 pillow==9.5.0
 pypinyin~=0.46.0
 pyyaml~=6.0
-requests-html
+requests-html~=0.10.0
+lxml_html_clean~=0.1.0
 srsly~=2.4.3
 starlette~=0.19.1
 zhon~=1.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ requests-html
 srsly~=2.4.3
 starlette~=0.19.1
 zhon~=1.1.5
+cos-python-sdk-v5~=1.9.27
+tencentcloud-sdk-python~=3.0.0


### PR DESCRIPTION
会出现No module named 'qcloud_cos'
为此要为兔兔引入两个新包